### PR TITLE
Add the role of a Package Developer

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,41 +29,23 @@ possible.
 
 These are the roles that can be assigned to The Project Community members:
 
-- Benevolent Director For Life (BDFL)
-- Steering Council Member
-- Community Managers
-- Package Maintainer
-- Package Author
-- Project Contributor
-- Project Founder
+- [Steering Council Member](#steering-council)
+- [Benevolent Director For Life (BDFL)](#benevolent-director-for-life-bdfl)
+- [Community Manager](#community-manager)
+- [Package Maintainer](#package-maintainer)
+- [Package Developer](#package-developer)
 
-The individuals currently occupying each role will be listed on our website
-[fatiando.org][website].
+Additionally, the following titles may also be assigned to people who
+have been involved in the project as a means of providing credict for their 
+contributions (without the responsibilities that come with one of the roles 
+above):
 
-### Benevolent Director For Life (BDFL)
+- [Package Author](#package-author)
+- [Project Contributor](#project-contributor)
+- [Project Founder](#project-founder)
 
-The Project will have a BDFL (Benevolent Dictator for Life).
-The BDFL is chair of the Steering Council (see below) and has the same
-responsibilities of other Council members.
-In addition:
-
-* As *Dictator*, they, have the authority to make all final decisions for The
-  Project.
-* As *Benevolent*, they, in practice, chooses to defer that authority to the
-  consensus of the Community and Steering Council.
-
-It is expected that the BDFL will only rarely assert their final authority.
-Because it is rarely used, we refer to the BDFL's final authority as a
-"special" or "overriding" vote.
-When it does occur, the BDFL's override typically happens in situations where
-there is a deadlock in building consensus among the Community.
-
-The BDFL can step down at any time, and acting in good faith, will also listen
-to serious calls to do so.
-The BDFL can appoint their successor, but it is expected that the Steering
-Council and the Community will be consulted on this decision.
-If the BDFL is unable to appoint a successor, the Steering Council will make
-this decision, preferably by consensus but, if needed, by a majority vote.
+**The individuals currently occupying each role will be listed on our website
+[fatiando.org][website].**
 
 ### Steering Council
 
@@ -98,8 +80,9 @@ that capacity.
 A newly elected Member will be mentored in their role by an existing Council
 Member (appointed by the Council) until they feel that the mentorship is no
 longer required.
-The initial Steering Council was appointed by the BDFL (Leonardo Uieda) in
-2022.
+
+> The initial Steering Council was appointed by the BDFL (Leonardo Uieda) in
+> 2022.
 
 If a Council member becomes inactive in the project for a period of one year,
 they will be considered for removal from the Council.
@@ -117,7 +100,32 @@ The Council reserves the right to eject current Members if they are deemed to
 be actively harmful to the project's well-being, and attempts at communication
 and conflict resolution have failed.
 
-### Community Managers
+### Benevolent Director For Life (BDFL)
+
+The Project will have a BDFL (Benevolent Dictator for Life).
+The BDFL is chair of the Steering Council (see below) and has the same
+responsibilities of other Council members.
+In addition:
+
+* As *Dictator*, they, have the authority to make all final decisions for The
+  Project.
+* As *Benevolent*, they, in practice, choose to defer that authority to the
+  consensus of the Community and Steering Council.
+
+It is expected that the BDFL will only rarely assert their final authority.
+Because it is rarely used, we refer to the BDFL's final authority as a
+"special" or "overriding" vote.
+When it does occur, the BDFL's override typically happens in situations where
+there is a deadlock in building consensus among the Community.
+
+The BDFL can step down at any time, and acting in good faith, will also listen
+to serious calls to do so.
+The BDFL can appoint their successor, but it is expected that the Steering
+Council and the Community will be consulted on this decision.
+If the BDFL is unable to appoint a successor, the Steering Council will make
+this decision, preferably by consensus but, if needed, by a majority vote.
+
+### Community Manager
 
 The main role of the Community Managers is to breath life into our Community.
 Community Managers are responsible for, among other things,
@@ -143,7 +151,7 @@ It is expected that they will employ standard IT safety procedures to secure
 passwords and account information (using a password manager, enabling
 two-factor authentication, avoiding duplication of passwords, etc).
 
-### Package Maintainers
+### Package Maintainer
 
 The Package Maintainers oversee and manage the development, maintenance,
 goals, and scope of a particular software package.
@@ -155,10 +163,12 @@ Their responsibilities are:
 * Reviewing contributions to the software in the form of pull requests, issues,
   and discussions.
 * Maintaining the health and viability of the software.
+* Leading discussions about the software goals, scope, design, and 
+  future directions.
 * Managing the release of new versions of the software.
 * Delegating responsibility for development and review to other Project
   Contributors.
-* Recruiting and mentoring new Maintainers and Contributors
+* Recruiting and mentoring new Developers and Maintainers.
 
 Package Maintainers are appointed by existing Package Maintainers for the
 particular software upon consultation with the Steering Council.
@@ -179,7 +189,40 @@ It is expected that they will employ standard IT safety procedures to secure
 shared passwords and their own accounts (using a password manager, enabling
 two-factor authentication, avoiding duplication of passwords, etc).
 
-### Package Authors
+### Package Developer
+
+The Package Developers are the ones who regularly handle most of the code 
+and documentation development for each package in The Project.
+Each of the software packages developed by The Project will have a team of
+Package Developers.
+Their responsibilities are:
+
+* Welcoming new contributors to the software.
+* Reviewing contributions to the software in the form of pull requests, issues,
+  and discussions.
+* Participating in discussions about the software goals, scope, design, and 
+  future directions.
+* Taking an active role in the development of new features, bug fixes, and 
+  documentation.
+* Mentoring new Package Developers.
+
+Package Developers are appointed by existing Package Maintainers and Developers 
+for the particular software at their discretion.
+To be eligible for appointment as a Package Developer, an individual must be a
+Project Contributor who has produced regular code or documentation contributions 
+to the software.
+Developers can step down from their role at any time.
+It is expected that they will notify the Package Maintainers and fellow
+Developers promptly when deciding to step down.
+Package Developers who become inactive for a period of one year or more may be 
+removed from their role by the Package Maintainers.
+
+Package Developers will have write (`git push`) access to the software repository.
+It is expected that they will employ standard IT safety procedures to secure
+their own accounts (using a password manager, enabling two-factor authentication, 
+avoiding duplication of passwords, etc).
+
+### Package Author
 
 The Package Authors are the official authors and copyright holders for each
 software package developed by The Project.
@@ -187,7 +230,7 @@ Package Authors are listed in the `AUTHORS.md` file of each software repository.
 The processes and rules for becoming a Package Author are laid out in our
 [Authorship Guide][authorship].
 
-### Project Contributors
+### Project Contributor
 
 The Project Contributors are anyone who has made a contribution to The Project.
 Contributions include, but are not limited to, code, code review,
@@ -200,7 +243,7 @@ There are no responsibilities or powers assigned to Project Contributors.
 Candidates for the other roles in The Project governance are mostly recruited
 from the pool of Project Contributors.
 
-### Project Founders
+### Project Founder
 
 The Project Founders are the people who played a role in the conceptualization
 of The Project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,7 +30,7 @@ possible.
 These are the roles that can be assigned to The Project Community members:
 
 - [Steering Council Member](#steering-council)
-- [Benevolent Director For Life (BDFL)](#benevolent-director-for-life-bdfl)
+- [Benevolent Dictator For Life (BDFL)](#benevolent-dictator-for-life-bdfl)
 - [Community Manager](#community-manager)
 - [Package Maintainer](#package-maintainer)
 - [Package Developer](#package-developer)
@@ -100,7 +100,7 @@ The Council reserves the right to eject current Members if they are deemed to
 be actively harmful to the project's well-being, and attempts at communication
 and conflict resolution have failed.
 
-### Benevolent Director For Life (BDFL)
+### Benevolent Dictator For Life (BDFL)
 
 The Project will have a BDFL (Benevolent Dictator for Life).
 The BDFL is chair of the Steering Council (see below) and has the same

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -55,7 +55,7 @@ project, both technically and as a community.
 It is expected that all communication between the Council will be carried out
 in the open through one of The Project's [communication channels][contact].
 
-The Council are responsible for planning, organization, and direction of The
+The Council is responsible for planning, organization, and direction of The
 Project's operations and programs.
 There is an expectation that Steering Council members will attend regular
 online meetings and invest effort in community and organizational strategy, as
@@ -176,7 +176,7 @@ To be eligible for appointment as a Package Maintainer, an individual must be a
 Project Contributor who has produced code contributions to the software that
 are substantial in quality and quantity, and sustained over at least one year.
 The Steering Council can also appoint a Package Maintainer in special
-circumstances, for example of a software has no currently acting Maintainer.
+circumstances, for example if a software has no currently acting Maintainer.
 Maintainers can step down from their role at any time.
 It is expected that they will notify the Steering Council and fellow
 Maintainers with at least one month notice so that a replacement can be


### PR DESCRIPTION
Create a role between maintainer and contributor which reflects how we operate in practice. Developers have write access to the repository and certain responsibilities which we currently assign informally. This formalizes the role. Also separate the "roles" from "titles" (author, contributor, founder) which have no responsibilities attached are there for recognition only.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
