### PR TITLE
Add Burocrata to the list of repos for maintenance tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintenance_task.md
+++ b/.github/ISSUE_TEMPLATE/maintenance_task.md
@@ -24,6 +24,7 @@ Edit the list of repositories where this should be implemented.
 - [ ] [ensaio](https://github.com/fatiando/ensaio)
 - [ ] [choclo](https://github.com/fatiando/choclo)
 - [ ] [dependente](https://github.com/fatiando/dependente)
+- [ ] [burocrata](https://github.com/fatiando/burocrata)
 - [ ] [website](https://github.com/fatiando/website)
 - [ ] [tutorials](https://github.com/fatiando/tutorials)
 - [ ] [community](https://github.com/fatiando/community)


### PR DESCRIPTION
The new tool should be included in the list of repos generated for a maintenance task type issue.


