### PR TITLE
Remove pylint from instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,9 +213,11 @@ directory).
 
 ### Code style
 
-We use [Black](https://github.com/ambv/black) to format the code so we don't have to
+We use [Black](https://github.com/psf/black) and
+[isort](https://pycqa.github.io/isort/) to format the code so we don't have to
 think about it.
 Black loosely follows the [PEP8](http://pep8.org) guide but with a few differences.
+And isort sorts imports in a nice way.
 Regardless, you won't have to worry about formatting the code yourself.
 Before committing, run it to automatically format your code:
 
@@ -227,14 +229,12 @@ Don't worry if you forget to do it.
 Our continuous integration systems will warn us and you can make a new commit with the
 formatted code.
 
-We also use [flake8](http://flake8.pycqa.org/en/latest/) and
-[pylint](https://www.pylint.org/) to check the quality of the code and quickly catch
-common errors.
-The [`Makefile`](Makefile) contains rules for running both checks:
+We also use [flake8](http://flake8.pycqa.org/en/latest/) to check the quality
+of the code and quickly catch common errors.
+The [`Makefile`](Makefile) contains rules for running style and format checks:
 
 ```bash
-make check   # Runs flake8 and black (in check mode)
-make lint    # Runs pylint, which is a bit slower
+make check   # Runs flake8, and black and isort (in check mode).
 ```
 
 #### Docstrings


### PR DESCRIPTION
Update the instructions to check for style in our libraries in the `CONTRIBUTING.md` file: remove `pylint` since we are not using it anymore and add `isort` to the list of auto-formatters we use. Update link to Black website.


**Relevant issues/PRs:**

Fixes #160
